### PR TITLE
Added statistics modification threshold rather than mods > 0

### DIFF
--- a/AzureSQLMaintenance.txt
+++ b/AzureSQLMaintenance.txt
@@ -191,7 +191,9 @@ begin
 			,sp.modification_counter
 		into #statsBefore
 		from sys.stats s cross apply sys.dm_db_stats_properties(s.object_id,s.stats_id) sp 
-		where OBJECT_SCHEMA_NAME(s.object_id) != 'sys' and /*Modified stats or Dummy mode*/(sp.modification_counter>0 or @mode='dummy')
+		where 
+            OBJECT_SCHEMA_NAME(s.object_id) != 'sys' 
+            AND /*Modified stats or Dummy mode*/(sp.modification_counter > sp.rows_sampled * 0.9 or @mode='dummy')
 		order by sp.last_updated asc
 
 		/*Remove statistics if it is handled by index rebuild / reorginize 


### PR DESCRIPTION
Doing a FULLSCAN of statistics as soon as any modifications are made is too eager. Added the condition mod_rows > sampled_rows * 0.9