### PR TITLE
Re #39 - Ignore External Tables

### DIFF
--- a/AzureSQLMaintenance.txt
+++ b/AzureSQLMaintenance.txt
@@ -243,7 +243,8 @@ begin
 		and (alloc_unit_type_desc = 'IN_ROW_DATA' /*avoid LOB_DATA or ROW_OVERFLOW_DATA*/ or alloc_unit_type_desc is null /*for ColumnStore indexes*/)
 		and OBJECT_SCHEMA_NAME(idxs.object_id) != 'sys'
 		and idxs.is_disabled=0
-		and obj.type_desc != 'TF' /* Ignore table value functions */
+		and obj.type <> 'TF' /* Ignore table value functions */
+		and not exists ( select * from sys.external_tables as et where et.object_id = obj.object_id )
 		order by i.avg_fragmentation_in_percent desc, i.page_count desc
 				
 		-- mark indexes XML,spatial and columnstore not to run online update 


### PR DESCRIPTION
Anti-Semi-Join against sys.external_tables on matching object_id to exclude External Tables
Also fix for ignoring TVFs - the [type] column is a 1 or 2 letter code, 'TF' for Table Valued Functions, whereas the [type_desc] is a brief description, 'SQL_TABLE_VALUED_FUNCTION' for Table Valued Functions.