### PR TITLE
Prevent error when current SQL Server version does not support RESUMABLE

### DIFF
--- a/AzureSQLMaintenance.txt
+++ b/AzureSQLMaintenance.txt
@@ -381,7 +381,7 @@ begin
 		case when OperationToTake='REBUILD' 
 			then 'WITH(MAXDOP=1'  + 
 			case when OnlineOpIsNotSupported=1 then ',ONLINE=OFF' else ',ONLINE=ON' end +
-			case when @ResumableIndexRebuild=1 and @ResumableIndexRebuildSupported=1 and ObjectDoesNotSupportResumableOperation=0 then ',RESUMABLE=ON' else ',RESUMABLE=OFF' end + 
+			case when @ResumableIndexRebuild=1 and @ResumableIndexRebuildSupported=1 and ObjectDoesNotSupportResumableOperation=0 then ',RESUMABLE=ON' else '' end + 
 			case when SortInTempDB=1 then ',SORT_IN_TEMPDB=ON' else ',SORT_IN_TEMPDB=OFF' end +
 			')' 
 			else /* Operation is reoranize*/ '' end + 


### PR DESCRIPTION
I want to use your script AzureSQLMaintenance with a version of SQL Server that does not support RESUMABLE.

The script does check for that situation. However, when RESUMABLE is not supported, or parameter @ResumableIndexRebuild = 0, the script adds "RESUMABLE=OFF" to the "ALTER INDEX REBUILD" command.

This causes an error, because my older version of SQL Server doesn't recognize RESUMABLE at all, including "RESUMABLE=OFF"

This pull request changes the code, so when RESUMABLE is not supported, or parameter @ResumableIndexRebuild = 0, it doesn't add "RESUMABLE=OFF". "OFF" is the default anyway for RESUMABLE, so this doesn't change existing behavior when the script runs. 

When RESUMABLE is supported, and parameter @ResumableIndexRebuild = 1, it still adds "RESUMABLE=ON"